### PR TITLE
Remove redundant imports

### DIFF
--- a/aws_bedrock_langchain_python_cdk/aws_bedrock_langchain_python_cdk_stack.py
+++ b/aws_bedrock_langchain_python_cdk/aws_bedrock_langchain_python_cdk_stack.py
@@ -1,6 +1,4 @@
 from aws_cdk import (
-    Stack,
-    Duration,
     aws_iam as iam,
     aws_lambda as _lambda,
     aws_lambda_python_alpha as _alambda,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This pull request makes a minor change to the `aws_bedrock_langchain_python_cdk_stack.py` file by removing unused imports, specifically `Stack` and `Duration`, to clean up the code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

